### PR TITLE
🛡️ Sentinel: CRITICAL Remove Hardcoded Secrets from Docker Configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 DB_HOST=db
 DB_PORT=5432
 DB_USERNAME=richk
-DB_PASSWORD=changeme
+DB_PASSWORD=
 POSTGRES_DB=richkware
 
 # Encryption Key - MUST be changed in production

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2024-01-27 - Hardcoded Default Secrets in Docker Configuration
+
+**Vulnerability:** The application's `Dockerfile` and `docker-compose.yml` files contained hardcoded default credentials (e.g., `DB_PASSWORD=changeme`) and secrets (`ENCRYPTION_KEY=changeme`).
+
+**Learning:** This pattern creates a significant security risk. Developers might inadvertently run the application in a development or even production environment with these known, weak credentials. The `Dockerfile` baked the secrets into the image layers, and `docker-compose.yml` provided insecure fallbacks, making a secure setup optional rather than enforced. The application was also missing a necessary secret (`ENCRYPTION_KEY`) in its runtime configuration in `docker-compose.yml`, which would likely lead to runtime errors or insecure operation.
+
+**Prevention:** All secrets must be removed from `Dockerfile` `ENV` default values and from `docker-compose.yml` fallback values. Configuration should rely exclusively on environment variables passed at runtime (e.g., from a `.env` file that is not checked into version control). The `.env.example` file should use placeholder values like `<your-secure-password>` instead of actual default passwords to guide developers. All secrets required by the application must be explicitly passed to the container in `docker-compose.yml`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ EXPOSE 8080
 ENV DB_HOST=db \
     DB_PORT=5432 \
     DB_USERNAME=richk \
-    DB_PASSWORD=changeme \
-    ENCRYPTION_KEY=changeme \
     DEBUG_MODE=false \
     SPRING_PROFILES_ACTIVE=docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       POSTGRES_DB: richkware
       POSTGRES_USER: ${DB_USERNAME:-richk}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-changeme}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
     volumes:
       - db_data:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
@@ -29,7 +29,8 @@ services:
       DB_HOST: db
       DB_PORT: 5432
       DB_USERNAME: ${DB_USERNAME:-richk}
-      DB_PASSWORD: ${DB_PASSWORD:-changeme}
+      DB_PASSWORD: ${DB_PASSWORD}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       SPRING_PROFILES_ACTIVE: docker
     ports:
       - "8080:8080"


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Hardcoded default secrets (database password and encryption key) in Docker configuration files (`Dockerfile`, `docker-compose.yml`).
🎯 **Impact:** If the application were deployed using the default configuration, it would use known, weak credentials, making it highly vulnerable to unauthorized access and compromise.
🔧 **Fix:** Removed all hardcoded default values and fallbacks for secrets from the `Dockerfile` and `docker-compose.yml`. The application will now fail to start unless these secrets are provided via environment variables (e.g., a local `.env` file), enforcing a secure configuration.
✅ **Verification:**
1.  Inspect `Dockerfile`: Confirm that `ENV` definitions for `DB_PASSWORD` and `ENCRYPTION_KEY` have no default values.
2.  Inspect `docker-compose.yml`: Confirm that `DB_PASSWORD`, `POSTGRES_PASSWORD`, and `ENCRYPTION_KEY` are read from variables (e.g., `${DB_PASSWORD}`) and have no `:-changeme` fallbacks.
3.  Attempt to run `docker-compose up` without a `.env` file. The server container should fail to start due to missing environment variables.

---
*PR created automatically by Jules for task [11611073938290474266](https://jules.google.com/task/11611073938290474266) started by @richkmeli*