### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove hardcoded sensitive secrets from configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,11 @@
 DB_HOST=db
 DB_PORT=5432
 DB_USERNAME=richk
-DB_PASSWORD=changeme
+DB_PASSWORD=
 POSTGRES_DB=richkware
 
 # Encryption Key - MUST be changed in production
-ENCRYPTION_KEY=ChangeThisSecureKey123!
+ENCRYPTION_KEY=
 
 # Spring Profile
 SPRING_PROFILES_ACTIVE=docker

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-01-31 - Hardcoded Secrets in Docker and Config files
+**Vulnerability:** Sensitive credentials (DB_USERNAME, DB_PASSWORD, ENCRYPTION_KEY) were hardcoded as default values in Dockerfile, docker-compose.yml, and application properties.
+**Learning:** Hardcoded secrets in a Dockerfile's ENV instruction are baked into the image layers and can be extracted using `docker history` or `docker inspect`, even if overwritten at runtime.
+**Prevention:** Always use runtime environment variables for secrets. Remove all default values for sensitive parameters from configuration files and force them to be provided via a secure mechanism like an `.env` file (not committed) or a secret manager.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,6 @@ EXPOSE 8080
 
 ENV DB_HOST=db \
     DB_PORT=5432 \
-    DB_USERNAME=richk \
-    DB_PASSWORD=changeme \
-    ENCRYPTION_KEY=changeme \
     DEBUG_MODE=false \
     SPRING_PROFILES_ACTIVE=docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,15 @@ services:
     image: postgres:15
     environment:
       POSTGRES_DB: richkware
-      POSTGRES_USER: ${DB_USERNAME:-richk}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-changeme}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
     volumes:
       - db_data:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-richk}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -28,8 +28,9 @@ services:
     environment:
       DB_HOST: db
       DB_PORT: 5432
-      DB_USERNAME: ${DB_USERNAME:-richk}
-      DB_PASSWORD: ${DB_PASSWORD:-changeme}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       SPRING_PROFILES_ACTIVE: docker
     ports:
       - "8080:8080"

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,7 +1,7 @@
 # DOCKER (Postgres)
 spring.datasource.url=jdbc:postgresql://${DB_HOST:db}:${DB_PORT:5432}/${POSTGRES_DB:richkware}
-spring.datasource.username=${DB_USERNAME:richk}
-spring.datasource.password=${DB_PASSWORD:changeme}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 
 # Use PostgreSQL dialect to avoid MySQL-specific SQL (backticks, etc.)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded default credentials and encryption keys in `Dockerfile`, `docker-compose.yml`, and `application-docker.properties`.
🎯 Impact: Attackers can easily gain access to the database or decrypt sensitive data if the application is deployed with default settings. Furthermore, secrets hardcoded in `Dockerfile` are stored in the image layers.
🔧 Fix: Removed hardcoded defaults for `DB_USERNAME`, `DB_PASSWORD`, and `ENCRYPTION_KEY`. Updated `docker-compose.yml` to pass these as runtime environment variables and updated `.env.example` to guide users in providing secure values.
✅ Verification: Inspected all modified files to ensure no hardcoded secrets remain and environment variable mappings are correct. Attempted `mvn test` (fails due to unrelated missing `GITHUB_TOKEN`).

---
*PR created automatically by Jules for task [5302813604848524134](https://jules.google.com/task/5302813604848524134) started by @richkmeli*